### PR TITLE
Documentation, filter to change mailchimp form selector

### DIFF
--- a/classes/class-news-match-popup-basics-mailchimp.php
+++ b/classes/class-news-match-popup-basics-mailchimp.php
@@ -82,6 +82,13 @@ class News_Match_Popup_Basics_Mailchimp {
 			'news_match_popup_basics_mailchimp',
 			array(
 				'campaign' => $options['mailchimp_campaign'],
+				/**
+				 * @filter news_match_popup_basics_mailchimp_selector
+				 * @param string $selector A CSS selector that chooses mailchimp forms within Popup Maker popups; default is '.pum #mc_embed_signup'.
+				 * @return string The new selector.
+				 * @since 0.1.2
+				 */
+				'selector' => apply_filters( 'news_match_popup_basics_mailchimp_selector', '.pum #mc_embed_signup' )
 			)
 		);
 		wp_enqueue_script(

--- a/js/exclude.js
+++ b/js/exclude.js
@@ -9,7 +9,7 @@
 			if ( news_match_popup_basics_mailchimp.selector ) {
 				var $popup = PUM.getPopup( news_match_popup_basics_mailchimp.selector );
 			} else {
-				var $popup = PUM.getPopup( '#mc_embed_signup' );
+				var $popup = PUM.getPopup( '.pum #mc_embed_signup' );
 				console.log( 'Something is wrong with the filter applied to \'news_match_popup_basics_mailchimp_selector\'. Please ensure that it is returning a string and that that string is a valid CSS selector' );
 			}
 

--- a/js/exclude.js
+++ b/js/exclude.js
@@ -1,12 +1,18 @@
 (function ($) {
 	$(document).on( 'pumBeforeOpen', function( ) {
-		var $popup = PUM.getPopup('.pum #mc_embed_signup');
-
-		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Using_special_characters
+		// escape the string for the regex via https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Using_special_characters
 		var escaped = news_match_popup_basics_mailchimp.campaign.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 		var match = new RegExp( 'utm_source=' + escaped, 'i' );
 
 		if (window.location.href.match( match )) {
+
+			if ( news_match_popup_basics_mailchimp.selector ) {
+				var $popup = PUM.getPopup( news_match_popup_basics_mailchimp.selector );
+			} else {
+				var $popup = PUM.getPopup( '#mc_embed_signup' );
+				console.log( 'Something is wrong with the filter applied to \'news_match_popup_basics_mailchimp_selector\'. Please ensure that it is returning a string and that that string is a valid CSS selector' );
+			}
+
 			// @since Popup Maker v1.6.6
 			$popup.addClass('preventOpen');
 		}

--- a/news-match-popup-basics.php
+++ b/news-match-popup-basics.php
@@ -1,20 +1,21 @@
 <?php
 /**
  * Plugin Name: News Match Popup Basics
- * Plugin URI:  https://github.com/INN/news-match-popup-plugin
+ * Plugin URI:  https://wordpress.org/plugins/news-match-popup-basics
  * Description: An introduction to popups for Knight News Match program particpants, and others
- * Version:     0.1.1
+ * Version:     0.1.2
  * Author:      innlabs
  * Author URI:  https://labs.inn.org
  * Donate link: https://labs.inn.org
  * License:     GPLv2 or later
  * Text Domain: news-match-popup-basics
  * Domain Path: /languages
+ * Requires at least: 4.8.2
  *
  * @link    https://labs.inn.org
  *
  * @package News_Match_Popup_Basics
- * @version 0.1.1
+ * @version 0.1.2
  */
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: innlabs
 Tags: popup, popmake
 Tested up to: 4.8.2
 Requires PHP: 7
-Stable tag: 0.1.1
+Stable tag: 0.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -60,6 +60,51 @@ In the WordPress Dashboard, under the "Popup Maker" menu item, on the "News Matc
 From one of the emails you have sent, find a link that contains a `utm_source=` parameter and copy the following argument text, up until any `&` character, into the text box. For example, a Nerd Alert newsletter sent by INN Labs contained a link that looked like this: `https://example.org/?utm_source=Nerd+Alert&utm_campaign=4d4ecd9f68-EMAIL_CAMPAIGN_2017_10_06&utm_medium=email&utm_term=0_1476113985-4d4ecd9f68-421742753`. From that URL, you would copy `Nerd+Alert` into the text box.
 
 Once you have provided a `utm_source` parameter, checked the checkbox, and saved the settings, any popup that contains an HTML element with an `id` attribute equal to `mc_embed_signup`, or a CSS selector equal to `#mc_embed_signup`, will be suppressed. Suppression works client-side using JavaScript that runs in the visitor's browser.
+
+= Why does MailChimp popup suppression use `#mc_embed_signup`? =
+
+When you generate [a MailChimp embedded signup form](https://kb.mailchimp.com/lists/signup-forms/add-a-signup-form-to-your-website), MailChimp provides HTML by default that looks like this:
+
+```html
+<!-- Begin MailChimp Signup Form -->
+<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+	#mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+	/* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
+	   We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+</style>
+<div id="mc_embed_signup">
+	<form action="" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+		<div id="mc_embed_signup_scroll">
+			<h2>Subscribe to our mailing list</h2>
+
+			... the actual form ...
+
+			<!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+			<div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="" tabindex="-1" value=""></div>
+			<div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+		</div>
+	</form>
+</div>
+<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='MMERGE3';ftypes[3]='radio';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+<!--End mc_embed_signup-->
+```
+
+News Match Popup Basics uses `#mc_embed_signup` as the selector for disabling MailChimp signup forms because that's what MailChimp uses. You can also apply a filter to `news_match_popup_basics_mailchimp_selector` to change the selector; your filter function should accept a string as its first parameter and return a string. There are no other parameters:
+
+```php
+/**
+ * Filter to change the News Match Popup Basics mailchimp suppression selector
+ *
+ * @since News Match Popup Basics 0.1.2
+ * @param string $selector A CSS selector that chooses mailchimp forms within Popup Maker popups; default is '.pum #mc_embed_signup'.
+ * @return string The new selector
+ */
+function my_filter( $selector ) {
+	return '.pum .class_added_to_all_mailchimp_forms';
+}
+add_filter( 'news_match_popup_basics_mailchimp_selector', 'my_filter' );
+```
 
 = How does the donation page popup suppression work? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -43,12 +43,15 @@ The popup:
 - automatically opens after 25 seconds on the page, because immediate popup appearances can be jarring
 - once dismissed by a reader, does not appear again for a year or until the reader clears their browser's cookies, whichever comes first
 - appears on the front page of the site
+- uses Popup Maker's default theme
 
 For more about Popup Maker's options for popup placement and behavior, read [the Popup Maker documentation for the Popup Editor](http://docs.wppopupmaker.com/article/39-creating-a-popup).
 
 = Can I change those settings? =
 
 Once the popup is created, you can modify the popup just like any other popup. The popup will not appear on your site until you publish it.
+
+To change the appearance of the popup, you can use [Popup Maker's included theming engine](http://docs.wppopupmaker.com/category/154-theming-popups), CSS in your site's theme, [Jetpack's Custom CSS Editor](https://jetpack.com/support/custom-css/), or other tools that allow you to define new styles.
 
 = How does the MailChimp popup suppression work? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -68,4 +68,10 @@ Once at least one URL has been added to the text box, and the check box has been
 
 No.
 
+= Is there advice specific to Knight News Match program participants? =
+
+We recommend that you use the [News Match Donation Shortcode](https://wordpress.org/plugins/news-match-donation-shortcode) plugin to place donation forms in popups on your site, and on your site's donation page.
+
+We also recommend you use this plugin's suppression features to prevent all popups from appearing on your donation and subscription pages.
+
 == Changelog ==


### PR DESCRIPTION
## Changes:

- bumps version number to 0.1.2
- adds required WordPress version of 4.8.2 because everyone should be on that now
- adds a filter `news_match_popup_basics_mailchimp_selector` to allow changing the selector for the script-based prevention of mailchimp popups, in case someone needs to change that.
- change layout of `js/exclude.js` to not find the element unless the page URL matches: saves some cycles and memory
- sets plugin URI to the wp.org plugin page
- adds some recommendations for the donation plugin (#5), theming (#4), and newsletter signup (#3)

## Questions:

Is https://github.com/INN/news-match-popup-plugin/issues/19 a problem?